### PR TITLE
Refactor score expression configuration handling

### DIFF
--- a/src/tometo_tomato/tometo_tomato.py
+++ b/src/tometo_tomato/tometo_tomato.py
@@ -199,7 +199,13 @@ def try_load_rapidfuzz(con: duckdb.DuckDBPyConnection) -> bool:
 def choose_score_expr(
     using_rapidfuzz: bool,
     join_pairs: List[str],
+def choose_score_expr(
+    using_rapidfuzz: bool,
+    join_pairs: List[str],
     scorer: str,
+    args: "argparse.Namespace",
+    preprocessed: bool = False,
+) -> str:
     args,
     preprocessed: bool = False,
 ) -> str:

--- a/src/tometo_tomato/tometo_tomato.py
+++ b/src/tometo_tomato/tometo_tomato.py
@@ -231,7 +231,7 @@ def choose_score_expr(
                 exprs.append(
                     f"(1.0 - CAST(levenshtein(ref.\"{ref_col}_clean\", inp.\"{inp_col}_clean\") AS DOUBLE) "
                     f"/ NULLIF(GREATEST(LENGTH(ref.\"{ref_col}_clean\"), LENGTH(inp.\"{inp_col}_clean\")),0)) * 100"
-                )
+    def clean_column_expr(table_alias: str, column: str, args: "argparse.Namespace") -> str:
         return " + ".join(exprs)
 
     def clean_column_expr(table_alias: str, column: str, args) -> str:


### PR DESCRIPTION
## Summary
- Pass configuration namespace directly to `choose_score_expr` and its helper
- Remove dynamic lookup of args via `sys.modules`/`inspect`
- Update call sites to provide the config object

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaed3e17c883229828b15b09e55f3d